### PR TITLE
fix: 修复数值角标丢失与类型不兼容

### DIFF
--- a/main.js
+++ b/main.js
@@ -431,7 +431,7 @@ class Handler {
             const url = parameters.url || undefined
             const image = parameters.image || undefined
             const copy = parameters.copy || undefined
-            const badge = parameters.badge || undefined
+            const badge = parameters.badge === null || parameters.badge === undefined ? undefined : String(parameters.badge)
             const autoCopy = parameters.autocopy || undefined
             const action = parameters.action || undefined
             const iv = parameters.iv || undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "bark-worker",
     "description": "Bark Server on Cloudflare Worker",
+    "type": "module",
     "cloudflare": {
         "label": "Bark Server",
         "products": [
@@ -17,6 +18,7 @@
         "wrangler": "^4.84.1"
     },
     "scripts": {
+        "test": "node --test",
         "cf-typegen": "wrangler types",
         "db:migrate": "wrangler d1 migrations apply database --local",
         "db:migrate:remote": "wrangler d1 migrations apply database --remote",

--- a/test/push-compatibility.test.js
+++ b/test/push-compatibility.test.js
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import worker from '../main.js'
+
+class FakeD1Database {
+    exec() {}
+
+    prepare(query) {
+        return {
+            bind: (...bindings) => ({
+                run: async () => this.run(query, bindings),
+            }),
+            run: async () => this.run(query, []),
+        }
+    }
+
+    async run(query) {
+        if (query.includes('SELECT `token` FROM `devices`')) {
+            return { results: [{ token: 'test-device-token' }] }
+        }
+
+        if (query.includes('SELECT `token`, `time` FROM `authorization`')) {
+            return {
+                results: [{
+                    token: 'test-authorization-token',
+                    time: String(Math.floor(Date.now() / 1000)),
+                }],
+            }
+        }
+
+        return { results: [] }
+    }
+}
+
+function createWorkerContext() {
+    const pending = []
+
+    return {
+        context: {
+            waitUntil(promise) {
+                pending.push(promise)
+            },
+        },
+        async settle() {
+            await Promise.all(pending)
+        },
+    }
+}
+
+async function push(payload) {
+    const apnsRequests = []
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = async (url, init) => {
+        apnsRequests.push({ url, init })
+        return new Response(null, { status: 200 })
+    }
+
+    try {
+        const { context, settle } = createWorkerContext()
+        const response = await worker.fetch(new Request('https://worker.example/push', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify(payload),
+        }), {
+            database: new FakeD1Database(),
+            ALLOW_NEW_DEVICE: 'false',
+            ALLOW_QUERY_NUMS: 'false',
+            ROOT_PATH: '/',
+        }, context)
+
+        await settle()
+
+        assert.equal(response.status, 200)
+        assert.equal(apnsRequests.length, 1)
+
+        return JSON.parse(apnsRequests[0].init.body)
+    } finally {
+        globalThis.fetch = originalFetch
+    }
+}
+
+test('GET /ping remains compatible with the client health check', async () => {
+    const { context, settle } = createWorkerContext()
+    const response = await worker.fetch(new Request('https://worker.example/ping'), {
+        database: new FakeD1Database(),
+        ALLOW_NEW_DEVICE: 'false',
+        ALLOW_QUERY_NUMS: 'false',
+        ROOT_PATH: '/',
+    }, context)
+
+    await settle()
+
+    assert.equal(response.status, 200)
+    const body = await response.json()
+    assert.equal(body.code, 200)
+    assert.equal(body.message, 'pong')
+    assert.equal(typeof body.timestamp, 'number')
+})
+
+test('POST /push preserves the current client contract in the APNs payload', async () => {
+    const payload = await push({
+        device_key: 'test-device-key',
+        title: 'Build complete',
+        body: 'All checks passed',
+        group: 'Codex',
+        sound: 'bell',
+        icon: 'https://example.com/icon.png',
+        url: 'https://example.com/result',
+        copy: 'result-id',
+        level: 'active',
+        badge: 1,
+    })
+
+    assert.deepEqual(payload.aps.alert, {
+        title: 'Build complete',
+        body: 'All checks passed',
+    })
+    assert.equal(payload.aps.sound, 'bell.caf')
+    assert.equal(payload.aps['thread-id'], 'Codex')
+    assert.equal(payload.group, 'Codex')
+    assert.equal(payload.icon, 'https://example.com/icon.png')
+    assert.equal(payload.url, 'https://example.com/result')
+    assert.equal(payload.copy, 'result-id')
+    assert.equal(payload.level, 'active')
+    assert.equal(payload.badge, '1')
+})
+
+test('POST /push preserves badge=0 as a string so Bark can clear the badge', async () => {
+    const payload = await push({
+        device_key: 'test-device-key',
+        title: 'Badge cleared',
+        body: 'No unread notifications',
+        group: 'Codex',
+        badge: 0,
+    })
+
+    assert.equal(payload.badge, '0')
+})
+
+test('POST /push forwards every supported interruption level', async (t) => {
+    for (const level of ['passive', 'active', 'timeSensitive', 'critical']) {
+        await t.test(level, async () => {
+            const payload = await push({
+                device_key: 'test-device-key',
+                title: `Level: ${level}`,
+                body: 'Compatibility check',
+                group: 'Codex',
+                level,
+            })
+
+            assert.equal(payload.level, level)
+        })
+    }
+})


### PR DESCRIPTION
## 背景

当前 JSON 推送请求使用数值 `badge` 时存在两个兼容性问题：

- `parameters.badge || undefined` 会把 `badge=0` 当成空值丢弃，导致无法清除角标。
- 非零数值会以 JSON number 传入 Bark 扩展参数，而官方 Bark Server 的扩展参数使用字符串语义。

## 修改内容

- 仅在 `badge` 为 `null` 或 `undefined` 时省略该字段。
- 将有效角标值转换为字符串，因此 `badge=1` 会发送为 `"1"`，`badge=0` 会发送为 `"0"`。
- 增加基于 Node 内置测试框架的 Worker 集成测试，覆盖：
  - `/ping` 健康检查；
  - 当前推送字段；
  - `badge=1` 设置角标；
  - `badge=0` 清除角标；
  - `passive`、`active`、`timeSensitive`、`critical` 四种通知级别。

## 验证

```text
npm test
8 tests passed
```

本 PR 不包含任何部署环境、D1、域名或个人配置修改。